### PR TITLE
Add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Summary
- Add `.gitattributes` with `* text=auto eol=lf` to prevent CRLF issues on Windows
- Fixes `oxfmt --check` failures caused by CRLF line endings after git checkout

## Test plan
- [x] `npm run format:check` passes locally on Windows
- [x] CI passes