### PR TITLE
Add semantic status role to EmptyState

### DIFF
--- a/src/webview/components/empty-state/empty-state.tsx
+++ b/src/webview/components/empty-state/empty-state.tsx
@@ -4,7 +4,7 @@ interface EmptyStateProps {
 
 export function EmptyState({ message }: EmptyStateProps) {
   return (
-    <div className="flex items-center justify-center h-[80vh] text-description">
+    <div className="flex items-center justify-center h-[80vh] text-description" role="status">
       <p>{message}</p>
     </div>
   )

--- a/test/webview/emptyState.test.tsx
+++ b/test/webview/emptyState.test.tsx
@@ -1,0 +1,17 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen } from "@testing-library/preact"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { EmptyState } from "../../src/webview/components/empty-state/empty-state"
+
+afterEach(cleanup)
+
+describe("EmptyState", () => {
+  it("renders the empty state as a status region", () => {
+    render(<EmptyState message="No Tailwind classes detected in the current file." />)
+
+    const emptyState = screen.getByRole("status")
+    expect(emptyState).toBeTruthy()
+    expect(emptyState.textContent).toContain("No Tailwind classes detected in the current file.")
+  })
+})


### PR DESCRIPTION
## Summary
- add `role="status"` to the empty-state container so assistive tech announces it
- add a focused webview test that asserts the empty state renders with the status role

## Verification
- `npx vitest run test/webview/emptyState.test.tsx`
- `npx vitest run test/webview/panel.test.tsx test/webview/emptyState.test.tsx`
- `npm run typecheck`
- `./node_modules/.bin/oxfmt --check src/webview/components/empty-state/empty-state.tsx test/webview/emptyState.test.tsx`
- `git diff --check`

Closes #25