### PR TITLE
Fix panel disconnect and split-view decorations (#20)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,7 @@
       "type": "extensionHost",
       "request": "launch",
       "args": [
+        "${workspaceFolder}/sandbox",
         "--extensionDevelopmentPath=${workspaceFolder}",
         "--disable-extension",
         "beumerr.tailwind-stash"

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,6 @@
 .vscode/**
 .vscode-test/**
+sandbox/**
 .github/**
 src/**
 test/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the Tailwind Stash extension will be documented in this f
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.2.4] - 2026-03-14
+
+### Fixed
+
+- Fix class editor panel losing connection when switching editors or opening new tabs (#20)
+- Fix decorations only appearing on the active editor — now all visible editors in split view are decorated
+- Eliminate race condition where the panel could read stale ranges before FoldingManager had processed the new editor
+
+### Added
+
+- FoldingManager emits `onDidUpdateRanges` event so consumers react to genuine range changes, not stale cache
+- Manual testing sandbox (`sandbox/`) with 7 fixture files covering edge cases — F5 opens it automatically
+- 2 new unit tests (334 total)
+
 ## [0.2.3] - 2026-03-13
 
 ### Changed

--- a/oxlint.config.mjs
+++ b/oxlint.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig({
     es2024: true,
     node: true,
   },
-  ignorePatterns: ["scripts/", "meta.json"],
+  ignorePatterns: ["sandbox/", "scripts/", "meta.json"],
   jsPlugins: [
     "eslint-plugin-better-tailwindcss",
     "eslint-plugin-no-only-tests",
@@ -55,10 +55,12 @@ export default defineConfig({
       },
     },
     {
-      // Tests use JSX without explicit React/Preact import
+      // Tests use JSX without explicit React/Preact import.
+      // EventEmitter is from the VS Code API mock, not Node.js.
       files: ["test/**"],
       rules: {
         "react/react-in-jsx-scope": "off",
+        "unicorn/prefer-event-target": "off",
       },
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tailwind-stash",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tailwind-stash",
-      "version": "0.2.2",
+      "version": "0.2.4",
       "license": "MIT",
       "devDependencies": {
         "@tailwindcss/cli": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tailwind-stash",
   "displayName": "Tailwind Stash",
   "description": "Collapse Tailwind CSS class strings with bi-directional editor panel",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "license": "MIT",
   "publisher": "beumerr",
   "repository": {

--- a/sandbox/basics.html
+++ b/sandbox/basics.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Basics</title>
+  </head>
+  <body>
+    <!-- Single class attr, well above minClassCount -->
+    <div class="flex items-center gap-2 p-4 rounded hover:bg-blue-500">
+      Click me
+    </div>
+
+    <!-- Two attrs on separate lines -->
+    <section class="grid grid-cols-3 gap-4 p-6 bg-white">
+      <span class="text-sm font-bold text-red-500 mt-2">Label</span>
+    </section>
+
+    <!-- Exactly at default minClassCount (4) -->
+    <p class="mt-4 px-2 text-lg font-medium">Threshold</p>
+
+    <!-- Below minClassCount — should NOT fold -->
+    <p class="mt-4 px-2 text-lg">Below threshold</p>
+
+    <!-- Empty class — should NOT fold -->
+    <div class="">Empty</div>
+  </body>
+</html>

--- a/sandbox/edge-cases.vue
+++ b/sandbox/edge-cases.vue
@@ -1,0 +1,44 @@
+<template>
+  <!--
+    Edge cases for folding / panel behavior.
+
+    Test:
+      - Multi-line class strings fold correctly
+      - Template literals (`:class`) are handled
+      - Rapid edits don't cause panel disconnect
+      - Cursor on a folded line expands it immediately
+  -->
+
+  <!-- Multi-line class attribute -->
+  <div
+    class="
+      flex flex-col items-center justify-center
+      min-h-screen bg-gradient-to-br
+      from-blue-50 to-indigo-100
+      p-8 gap-6
+    "
+  >
+    <!-- Nested elements with classes -->
+    <div class="w-full max-w-md bg-white rounded-xl shadow-lg overflow-hidden">
+      <div class="p-6 space-y-4 border-b border-gray-100">
+        <h1 class="text-2xl font-bold text-gray-900 tracking-tight">
+          Edge Cases
+        </h1>
+      </div>
+
+      <!-- Dynamic classes (Vue :class binding) — should NOT fold the binding -->
+      <div :class="['flex', 'gap-2', condition ? 'bg-red-500' : 'bg-green-500']">
+        Dynamic
+      </div>
+
+      <!-- Class with special chars in Tailwind (brackets, slashes) -->
+      <div class="w-[calc(100%-2rem)] bg-black/10 text-[14px] leading-[1.6] p-4 rounded">
+        Arbitrary values
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const condition = true
+</script>

--- a/sandbox/many-classes.tsx
+++ b/sandbox/many-classes.tsx
@@ -1,0 +1,58 @@
+/**
+ * Stress test — many class ranges in one file.
+ *
+ * Verify:
+ *  - All ranges fold without lag
+ *  - Panel lists all entries and scrolls
+ *  - Selecting an entry in the panel scrolls the editor to it
+ *  - Rapid cursor movement between ranges stays responsive
+ */
+
+export function StressTest() {
+  return (
+    <div class="min-h-screen bg-gray-50 p-8 font-sans antialiased">
+      <div class="max-w-4xl mx-auto space-y-6 bg-white rounded-2xl shadow-xl p-8">
+        <h1 class="text-3xl font-extrabold text-gray-900 tracking-tight leading-none">
+          Stress Test
+        </h1>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 auto-rows-fr">
+          <div class="p-4 bg-red-50 border border-red-200 rounded-lg text-red-800 font-medium">
+            Card 1
+          </div>
+          <div class="p-4 bg-orange-50 border border-orange-200 rounded-lg text-orange-800 font-medium">
+            Card 2
+          </div>
+          <div class="p-4 bg-yellow-50 border border-yellow-200 rounded-lg text-yellow-800 font-medium">
+            Card 3
+          </div>
+          <div class="p-4 bg-green-50 border border-green-200 rounded-lg text-green-800 font-medium">
+            Card 4
+          </div>
+          <div class="p-4 bg-teal-50 border border-teal-200 rounded-lg text-teal-800 font-medium">
+            Card 5
+          </div>
+          <div class="p-4 bg-blue-50 border border-blue-200 rounded-lg text-blue-800 font-medium">
+            Card 6
+          </div>
+          <div class="p-4 bg-indigo-50 border border-indigo-200 rounded-lg text-indigo-800 font-medium">
+            Card 7
+          </div>
+          <div class="p-4 bg-purple-50 border border-purple-200 rounded-lg text-purple-800 font-medium">
+            Card 8
+          </div>
+          <div class="p-4 bg-pink-50 border border-pink-200 rounded-lg text-pink-800 font-medium">
+            Card 9
+          </div>
+        </div>
+
+        <div class="flex items-center justify-between pt-4 border-t border-gray-200">
+          <span class="text-sm text-gray-500 font-medium tabular-nums">9 items</span>
+          <button class="px-4 py-2 bg-indigo-600 text-white text-sm font-semibold rounded-lg shadow hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors">
+            Load More
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/sandbox/no-classes.ts
+++ b/sandbox/no-classes.ts
@@ -1,0 +1,25 @@
+/**
+ * A file with NO Tailwind classes.
+ *
+ * Verify:
+ *  - No fold decorations appear
+ *  - Panel shows empty state when this file is active
+ *  - Switching from a file with classes to this one clears the panel
+ *  - Switching back restores the panel entries
+ */
+
+export function add(a: number, b: number): number {
+  return a + b
+}
+
+export function greet(name: string): string {
+  return `Hello, ${name}!`
+}
+
+const config = {
+  theme: "dark",
+  language: "en",
+  fontSize: 14,
+}
+
+export default config

--- a/sandbox/panel-sync.tsx
+++ b/sandbox/panel-sync.tsx
@@ -1,0 +1,36 @@
+/**
+ * Panel sync / race-condition test.
+ *
+ * Steps to test:
+ *  1. Open class editor panel (Cmd/Ctrl+Shift+P → "Show CSS Preview")
+ *  2. Open this file — panel should show entries below
+ *  3. Switch to another sandbox file — panel should update instantly
+ *  4. Switch back — panel should show these entries again, no stale data
+ *  5. Open a NEW tab (e.g., split-view.tsx) — panel should follow
+ *  6. Close the other tab — panel should stay connected to this file
+ *  7. Edit a class string below via the panel — verify it writes to the right file
+ */
+
+export function Header() {
+  return (
+    <header class="sticky top-0 z-50 flex items-center justify-between px-6 py-3 bg-white border-b shadow-sm">
+      <div class="flex items-center gap-3 text-lg font-bold text-gray-900">
+        Logo
+      </div>
+      <nav class="hidden md:flex items-center gap-6 text-sm font-medium text-gray-600">
+        <a href="#">Home</a>
+        <a href="#">About</a>
+      </nav>
+    </header>
+  )
+}
+
+export function Footer() {
+  return (
+    <footer class="mt-auto py-8 px-6 bg-gray-900 text-gray-400 text-sm text-center">
+      <p class="max-w-2xl mx-auto leading-relaxed tracking-wide">
+        Footer content with enough classes to fold.
+      </p>
+    </footer>
+  )
+}

--- a/sandbox/split-view.tsx
+++ b/sandbox/split-view.tsx
@@ -1,0 +1,40 @@
+/**
+ * Split-view test — open this file AND basics.html side by side.
+ *
+ * Verify:
+ *  1. Both editors show fold decorations simultaneously
+ *  2. Clicking a fold in either editor expands it
+ *  3. The class editor panel tracks whichever editor is active
+ *  4. Editing classes in the panel updates the correct editor
+ */
+
+export function Card() {
+  return (
+    <div class="flex flex-col gap-4 p-6 bg-white rounded-lg shadow-md">
+      <h2 class="text-xl font-semibold text-gray-900 tracking-tight">
+        Title
+      </h2>
+      <p class="text-sm text-gray-600 leading-relaxed line-clamp-3">
+        Description goes here with enough text to test long class strings.
+      </p>
+      <button class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 focus:ring-2">
+        Action
+      </button>
+    </div>
+  )
+}
+
+export function Sidebar() {
+  return (
+    <aside class="w-64 h-screen bg-gray-50 border-r border-gray-200 overflow-y-auto">
+      <nav class="flex flex-col gap-1 p-4 text-sm font-medium">
+        <a class="px-3 py-2 rounded-md bg-blue-50 text-blue-700 font-semibold" href="#">
+          Dashboard
+        </a>
+        <a class="px-3 py-2 rounded-md text-gray-700 hover:bg-gray-100 transition-colors" href="#">
+          Settings
+        </a>
+      </nav>
+    </aside>
+  )
+}

--- a/sandbox/supported-functions.tsx
+++ b/sandbox/supported-functions.tsx
@@ -1,0 +1,51 @@
+/**
+ * Tests supported function syntaxes (cn, clsx, cva, twMerge, etc.).
+ *
+ * Verify:
+ *  - Each function call's class string is detected and folded
+ *  - Panel shows entries for function-based classes
+ *  - Editing via the panel works for function args too
+ */
+
+import { cn } from "some-lib"
+
+export function FunctionSyntax({ active }: { active: boolean }) {
+  return (
+    <div>
+      {/* cn() — class-variance-authority / shadcn pattern */}
+      <button
+        className={cn(
+          "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors",
+          active && "bg-blue-600 text-white shadow-sm hover:bg-blue-700",
+        )}
+      >
+        cn button
+      </button>
+
+      {/* clsx() */}
+      <div
+        className={clsx(
+          "flex items-center gap-2 p-4 rounded-lg border border-gray-200",
+          active && "ring-2 ring-blue-500 border-transparent shadow-md",
+        )}
+      >
+        clsx div
+      </div>
+
+      {/* twMerge() */}
+      <span
+        className={twMerge(
+          "text-base font-normal text-gray-700 leading-relaxed tracking-normal",
+          active && "text-lg font-semibold text-blue-900 tracking-tight",
+        )}
+      >
+        twMerge span
+      </span>
+
+      {/* Plain className string */}
+      <footer className="mt-8 py-4 px-6 bg-gray-100 text-gray-500 text-xs text-center rounded-b-lg">
+        Plain className
+      </footer>
+    </div>
+  )
+}

--- a/src/core/cssPreviewPanel.ts
+++ b/src/core/cssPreviewPanel.ts
@@ -4,7 +4,6 @@ import { join } from "node:path"
 // eslint-disable-next-line import/no-namespace -- vscode SDK requires namespace import
 import * as vscode from "vscode"
 
-import { debounce } from "../utils/utils"
 import { ClassRange } from "./classDetector"
 
 export class CSSPreviewPanel {
@@ -19,20 +18,16 @@ export class CSSPreviewPanel {
   private currentEditorUri: string = ""
   private lastContentKey: string = ""
   private lastActiveIndex: number = -1
-  private textChangeDebounce: { cancel: () => void; fn: (editor: vscode.TextEditor) => void }
 
   private constructor(
     panel: vscode.WebviewPanel,
     extensionPath: string,
     getClassRanges: (uri: string) => ClassRange[],
+    onDidUpdateRanges: vscode.Event<string>,
   ) {
     this.panel = panel
     this.extensionPath = extensionPath
     this.getClassRanges = getClassRanges
-    this.textChangeDebounce = debounce(
-      (editor: vscode.TextEditor) => this.updateForEditor(editor),
-      150,
-    )
 
     this.panel.webview.html = this.getHtml()
     this.sendConfig()
@@ -57,11 +52,14 @@ export class CSSPreviewPanel {
           this.updateForEditor(editor)
         }
       }),
-      vscode.workspace.onDidChangeTextDocument((e) => {
-        const editor = vscode.window.visibleTextEditors.find((ed) => ed.document === e.document)
-        if (editor) {
-          this.lastContentKey = ""
-          this.textChangeDebounce.fn(editor)
+      onDidUpdateRanges((uri) => {
+        if (uri === this.currentEditorUri) {
+          const editor = vscode.window.visibleTextEditors.find(
+            (ed) => ed.document.uri.toString() === uri,
+          )
+          if (editor) {
+            this.updateForEditor(editor)
+          }
         }
       }),
     )
@@ -78,15 +76,23 @@ export class CSSPreviewPanel {
     }
   }
 
-  static toggle(extensionPath: string, getClassRanges: (uri: string) => ClassRange[]) {
+  static toggle(
+    extensionPath: string,
+    getClassRanges: (uri: string) => ClassRange[],
+    onDidUpdateRanges: vscode.Event<string>,
+  ) {
     if (CSSPreviewPanel.currentPanel) {
       CSSPreviewPanel.currentPanel.dispose()
     } else {
-      CSSPreviewPanel.createOrShow(extensionPath, getClassRanges)
+      CSSPreviewPanel.createOrShow(extensionPath, getClassRanges, onDidUpdateRanges)
     }
   }
 
-  static createOrShow(extensionPath: string, getClassRanges: (uri: string) => ClassRange[]) {
+  static createOrShow(
+    extensionPath: string,
+    getClassRanges: (uri: string) => ClassRange[],
+    onDidUpdateRanges: vscode.Event<string>,
+  ) {
     const column = vscode.ViewColumn.Beside
 
     if (CSSPreviewPanel.currentPanel) {
@@ -104,7 +110,12 @@ export class CSSPreviewPanel {
       },
     )
 
-    CSSPreviewPanel.currentPanel = new CSSPreviewPanel(panel, extensionPath, getClassRanges)
+    CSSPreviewPanel.currentPanel = new CSSPreviewPanel(
+      panel,
+      extensionPath,
+      getClassRanges,
+      onDidUpdateRanges,
+    )
   }
 
   private async handleMessage(msg: { classes?: string; index?: number; type: string }) {
@@ -224,7 +235,6 @@ export class CSSPreviewPanel {
 
   dispose() {
     CSSPreviewPanel.currentPanel = undefined
-    this.textChangeDebounce.cancel()
     this.panel.dispose()
     this.disposables.forEach((d) => d.dispose())
   }

--- a/src/core/foldingProvider.ts
+++ b/src/core/foldingProvider.ts
@@ -8,6 +8,8 @@ import { formatPlaceholder, matchPlaceholders } from "./placeholderMatcher"
 
 /** Manages horizontal collapse decorations */
 export class FoldingManager {
+  private readonly _onDidUpdateRanges = new vscode.EventEmitter<string>()
+  readonly onDidUpdateRanges: vscode.Event<string> = this._onDidUpdateRanges.event
   private enabled: boolean
   private disposables: vscode.Disposable[] = []
   private classRanges: Map<string, ClassRange[]> = new Map()
@@ -16,6 +18,7 @@ export class FoldingManager {
   private selectionDebounce: { cancel: () => void; fn: (editor: vscode.TextEditor) => void }
   private textChangeDebounce: { cancel: () => void; fn: (editor: vscode.TextEditor) => void }
   private lastCursorLine: number = -1
+  private lastRangeKeys: Map<string, string> = new Map()
   private cachedConfig: {
     foldedTextColor: string
     minClassCount: number
@@ -44,11 +47,12 @@ export class FoldingManager {
     }, 150)
 
     this.disposables.push(
-      vscode.window.onDidChangeActiveTextEditor((editor) => {
-        if (editor) {
-          this.lastCursorLine = -1
-          this.updateDecorations(editor)
-        }
+      vscode.window.onDidChangeActiveTextEditor(() => {
+        this.lastCursorLine = -1
+        this.updateAllVisibleEditors()
+      }),
+      vscode.window.onDidChangeVisibleTextEditors(() => {
+        this.updateAllVisibleEditors()
       }),
       vscode.workspace.onDidChangeTextDocument((e) => {
         const editor =
@@ -85,18 +89,12 @@ export class FoldingManager {
           const updatedConfig = vscode.workspace.getConfiguration("tailwindStash")
           this.enabled = updatedConfig.get<boolean>("foldByDefault", true)
           this.cachedConfig = null
-          const editor = vscode.window.activeTextEditor
-          if (editor) {
-            this.updateDecorations(editor)
-          }
+          this.updateAllVisibleEditors()
         }
       }),
     )
 
-    const editor = vscode.window.activeTextEditor
-    if (editor) {
-      this.updateDecorations(editor)
-    }
+    this.updateAllVisibleEditors()
   }
 
   toggle() {
@@ -105,10 +103,7 @@ export class FoldingManager {
 
   setEnabled(value: boolean) {
     this.enabled = value
-    const editor = vscode.window.activeTextEditor
-    if (editor) {
-      this.updateDecorations(editor)
-    }
+    this.updateAllVisibleEditors()
     vscode.window.showInformationMessage(
       `Tailwind Stash: ${this.enabled ? "Collapsed" : "Expanded"}`,
     )
@@ -116,6 +111,12 @@ export class FoldingManager {
 
   getClassRanges(uri: string): ClassRange[] {
     return this.classRanges.get(uri) ?? []
+  }
+
+  updateAllVisibleEditors() {
+    for (const editor of vscode.window.visibleTextEditors) {
+      this.updateDecorations(editor)
+    }
   }
 
   updateDecorations(editor: vscode.TextEditor) {
@@ -146,7 +147,17 @@ export class FoldingManager {
     } = this.cachedConfig
 
     const ranges = detectClassRanges(editor.document, supportedFunctions, minClassCount)
-    this.classRanges.set(editor.document.uri.toString(), ranges)
+    const uri = editor.document.uri.toString()
+    this.classRanges.set(uri, ranges)
+
+    const rangeKey = ranges
+      .map(
+        (cr) =>
+          `${cr.range.start.line}:${cr.range.start.character}-${cr.range.end.line}:${cr.range.end.character}:${cr.classes.join(",")}`,
+      )
+      .join("|")
+    const rangesChanged = this.lastRangeKeys.get(uri) !== rangeKey
+    this.lastRangeKeys.set(uri, rangeKey)
 
     // Skip collapsing any range the cursor is currently on
     const cursorLine = editor.selection.active.line
@@ -199,9 +210,13 @@ export class FoldingManager {
       this.hideType,
       visibleRanges.map((cr) => ({ range: cr.range })),
     )
+    if (rangesChanged) {
+      this._onDidUpdateRanges.fire(uri)
+    }
   }
 
   dispose() {
+    this._onDidUpdateRanges.dispose()
     this.placeholderType.dispose()
     this.hideType.dispose()
     this.selectionDebounce.cancel()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,15 +20,21 @@ export function activate(context: vscode.ExtensionContext) {
       foldingManager.toggle()
     }),
     vscode.commands.registerCommand("tailwindStash.showCssPreview", () => {
-      CSSPreviewPanel.createOrShow(context.extensionPath, (uri) =>
-        foldingManager.getClassRanges(uri),
+      CSSPreviewPanel.createOrShow(
+        context.extensionPath,
+        (uri) => foldingManager.getClassRanges(uri),
+        foldingManager.onDidUpdateRanges,
       )
     }),
     vscode.commands.registerCommand("tailwindStash.hideCssPreview", () => {
       CSSPreviewPanel.hide()
     }),
     vscode.commands.registerCommand("tailwindStash.toggleCssPreview", () => {
-      CSSPreviewPanel.toggle(context.extensionPath, (uri) => foldingManager.getClassRanges(uri))
+      CSSPreviewPanel.toggle(
+        context.extensionPath,
+        (uri) => foldingManager.getClassRanges(uri),
+        foldingManager.onDidUpdateRanges,
+      )
     }),
     vscode.commands.registerCommand("tailwindStash.expandPlaceholder", () => {
       expandPlaceholderAtCursor()

--- a/test/__mocks__/vscode.ts
+++ b/test/__mocks__/vscode.ts
@@ -216,6 +216,34 @@ export function createMockDocument(text: string): MockDocument {
   }
 }
 
+// ─── EventEmitter mock ──────────────────────────────────────────────
+
+export class EventEmitter<T> {
+  private listeners: ((e: T) => void)[] = []
+
+  event = (listener: (e: T) => void) => {
+    this.listeners.push(listener)
+    return {
+      dispose: () => {
+        const idx = this.listeners.indexOf(listener)
+        if (idx >= 0) {
+          this.listeners.splice(idx, 1)
+        }
+      },
+    }
+  }
+
+  fire(data: T) {
+    for (const listener of this.listeners) {
+      listener(data)
+    }
+  }
+
+  dispose() {
+    this.listeners = []
+  }
+}
+
 // ─── Mock registries for testing ────────────────────────────────────
 
 const commandHandlers = new Map<string, (...args: unknown[]) => unknown>()
@@ -224,6 +252,7 @@ const eventListeners = {
   onDidChangeConfiguration: [] as ((...args: unknown[]) => void)[],
   onDidChangeTextDocument: [] as ((...args: unknown[]) => void)[],
   onDidChangeTextEditorSelection: [] as ((...args: unknown[]) => void)[],
+  onDidChangeVisibleTextEditors: [] as ((...args: unknown[]) => void)[],
 }
 
 export function _reset() {
@@ -370,6 +399,7 @@ export const window = {
   },
   onDidChangeActiveTextEditor: makeEventEmitter("onDidChangeActiveTextEditor"),
   onDidChangeTextEditorSelection: makeEventEmitter("onDidChangeTextEditorSelection"),
+  onDidChangeVisibleTextEditors: makeEventEmitter("onDidChangeVisibleTextEditors"),
   showInformationMessage(_msg: string) {},
   showTextDocument() {},
   visibleTextEditors: [] as unknown[],

--- a/test/core/cssPreviewPanel.test.ts
+++ b/test/core/cssPreviewPanel.test.ts
@@ -2,6 +2,7 @@ import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
+  EventEmitter,
   Position,
   Range,
   Selection,
@@ -15,6 +16,7 @@ import {
 import { CSSPreviewPanel, findActiveIndex } from "../../src/core/cssPreviewPanel"
 
 const extensionPath = path.resolve(__dirname, "../..")
+const noopEvent = new EventEmitter<string>().event
 
 function makeClassRange(
   startLine: number,
@@ -46,9 +48,10 @@ function createPanelWithEditor(text?: string, opts?: { cursorLine?: number }) {
     return [makeClassRange(0, 12, 0, 41, ["flex", "items-center", "p-4", "rounded"], "div")]
   })
 
-  CSSPreviewPanel.createOrShow(extensionPath, getClassRanges)
+  const rangesEmitter = new EventEmitter<string>()
+  CSSPreviewPanel.createOrShow(extensionPath, getClassRanges, rangesEmitter.event)
   const panel = _getLastPanel()!
-  return { editor, getClassRanges, panel }
+  return { editor, getClassRanges, panel, rangesEmitter }
 }
 
 beforeEach(() => {
@@ -153,7 +156,7 @@ describe("createOrShow", () => {
     createPanelWithEditor('<div class="flex items-center p-4 rounded">')
     const firstPanel = _getLastPanel()
 
-    CSSPreviewPanel.createOrShow(extensionPath, () => [])
+    CSSPreviewPanel.createOrShow(extensionPath, () => [], noopEvent)
     // Should not have created a new panel
     expect(_getLastPanel()).toBe(firstPanel)
   })
@@ -202,15 +205,15 @@ describe("hide", () => {
 describe("toggle", () => {
   it("creates panel when none exists", () => {
     window.activeTextEditor = undefined
-    CSSPreviewPanel.toggle(extensionPath, () => [])
+    CSSPreviewPanel.toggle(extensionPath, () => [], noopEvent)
     expect(CSSPreviewPanel.currentPanel).toBeDefined()
   })
 
   it("disposes panel when one exists", () => {
-    CSSPreviewPanel.toggle(extensionPath, () => [])
+    CSSPreviewPanel.toggle(extensionPath, () => [], noopEvent)
     expect(CSSPreviewPanel.currentPanel).toBeDefined()
 
-    CSSPreviewPanel.toggle(extensionPath, () => [])
+    CSSPreviewPanel.toggle(extensionPath, () => [], noopEvent)
     expect(CSSPreviewPanel.currentPanel).toBeUndefined()
   })
 })
@@ -399,8 +402,11 @@ describe("updateForEditor", () => {
     })
     const messagesBefore = panel._getMessages().length
 
-    // Fire the same selection event again (same line, same content)
-    _fireEvent("onDidChangeActiveTextEditor", editor)
+    // Fire selection change with same line — triggers updateForEditor with same content key
+    _fireEvent("onDidChangeTextEditorSelection", {
+      selections: [{ active: { line: 0 } }],
+      textEditor: editor,
+    })
 
     const newMessages = panel._getMessages().slice(messagesBefore)
     // Should not send a duplicate update
@@ -409,46 +415,52 @@ describe("updateForEditor", () => {
   })
 })
 
-// ─── text document change debounce ──────────────────────────────────
+// ─── onDidUpdateRanges event-driven sync ────────────────────────────
 
-describe("text document changes", () => {
-  it("debounces text document changes and clears content key", () => {
-    vi.useFakeTimers()
-    const { editor, panel } = createPanelWithEditor('<div class="flex items-center p-4 rounded">', {
-      cursorLine: 0,
-    })
+describe("onDidUpdateRanges event-driven sync", () => {
+  it("updates panel when onDidUpdateRanges fires for current URI", () => {
+    const { getClassRanges, panel, rangesEmitter } = createPanelWithEditor(
+      '<div class="flex items-center p-4 rounded">',
+      { cursorLine: 0 },
+    )
     const messagesBefore = panel._getMessages().length
 
-    _fireEvent("onDidChangeTextDocument", { document: editor!.document })
+    // Simulate ranges changing (different class list)
+    getClassRanges.mockReturnValue([
+      makeClassRange(0, 12, 0, 30, ["flex", "p-4", "rounded", "mt-2"], "div"),
+    ])
+    rangesEmitter.fire("file:///test.tsx")
 
-    // Should not have updated yet (debounced)
-    expect(panel._getMessages().length).toBe(messagesBefore)
-
-    vi.advanceTimersByTime(200)
-
-    // After debounce, should have sent an update (content key was cleared)
     const newMessages = panel._getMessages().slice(messagesBefore)
     const updateMsg = newMessages.find((m) => m.type === "update")
     expect(updateMsg).toBeDefined()
-    vi.useRealTimers()
   })
 
-  it("ignores text changes for a different document", () => {
-    vi.useFakeTimers()
-    const { panel } = createPanelWithEditor('<div class="flex items-center p-4 rounded">', {
-      cursorLine: 0,
-    })
+  it("skips update when onDidUpdateRanges fires but ranges are unchanged", () => {
+    const { panel, rangesEmitter } = createPanelWithEditor(
+      '<div class="flex items-center p-4 rounded">',
+      { cursorLine: 0 },
+    )
     const messagesBefore = panel._getMessages().length
 
-    // Fire a text change for a different document
-    _fireEvent("onDidChangeTextDocument", {
-      document: { uri: { toString: () => "file:///other.tsx" } },
-    })
-    vi.advanceTimersByTime(200)
+    // Fire event without changing getClassRanges — ranges are identical
+    rangesEmitter.fire("file:///test.tsx")
 
-    // Should not have sent any new messages
+    const newMessages = panel._getMessages().slice(messagesBefore)
+    const updateMsgs = newMessages.filter((m) => m.type === "update")
+    expect(updateMsgs).toHaveLength(0)
+  })
+
+  it("ignores onDidUpdateRanges for a different URI", () => {
+    const { panel, rangesEmitter } = createPanelWithEditor(
+      '<div class="flex items-center p-4 rounded">',
+      { cursorLine: 0 },
+    )
+    const messagesBefore = panel._getMessages().length
+
+    rangesEmitter.fire("file:///other.tsx")
+
     expect(panel._getMessages().length).toBe(messagesBefore)
-    vi.useRealTimers()
   })
 
   it("skips editor changes for output scheme", () => {
@@ -490,7 +502,7 @@ describe("text document changes", () => {
 
 describe("updateForEditor content key caching", () => {
   it("sends only setActive when content is unchanged but active index changes", () => {
-    const { editor, getClassRanges, panel } = createPanelWithEditor(
+    const { editor, getClassRanges, panel, rangesEmitter } = createPanelWithEditor(
       '<div class="flex items-center p-4 rounded">',
       { cursorLine: 0 },
     )
@@ -500,14 +512,17 @@ describe("updateForEditor content key caching", () => {
     const range2 = makeClassRange(2, 13, 2, 48, ["text-sm", "font-bold", "mt-2", "mx-auto"], "span")
     getClassRanges.mockReturnValue([range1, range2])
 
-    // First update at line 0
+    // First update via event
     editor!.selection = { active: { line: 0 } } as unknown as Selection
-    _fireEvent("onDidChangeActiveTextEditor", editor)
+    rangesEmitter.fire("file:///test.tsx")
     const messagesAfterFirst = panel._getMessages().length
 
-    // Second update at line 2 (same content, different active)
+    // Second update at line 2 (same content, different active) via selection change
     editor!.selection = { active: { line: 2 } } as unknown as Selection
-    _fireEvent("onDidChangeActiveTextEditor", editor)
+    _fireEvent("onDidChangeTextEditorSelection", {
+      selections: [{ active: { line: 2 } }],
+      textEditor: editor,
+    })
 
     const newMessages = panel._getMessages().slice(messagesAfterFirst)
     const setActiveMsgs = newMessages.filter((m) => m.type === "setActive")
@@ -712,7 +727,7 @@ describe("regression: panel shows classes on open (ready message)", () => {
     window.activeTextEditor = editor
     window.visibleTextEditors = [editor]
 
-    CSSPreviewPanel.createOrShow(extensionPath, () => [])
+    CSSPreviewPanel.createOrShow(extensionPath, () => [], noopEvent)
     const panel = _getLastPanel()!
 
     const messagesBefore = panel._getMessages().length
@@ -724,12 +739,12 @@ describe("regression: panel shows classes on open (ready message)", () => {
   })
 })
 
-describe("regression: visibleTextEditors for text document changes", () => {
+describe("regression: onDidUpdateRanges finds editor via visibleTextEditors", () => {
   it("uses visibleTextEditors to find editor when activeTextEditor is undefined", () => {
-    vi.useFakeTimers()
-    const { editor, panel } = createPanelWithEditor('<div class="flex items-center p-4 rounded">', {
-      cursorLine: 0,
-    })
+    const { editor, getClassRanges, panel, rangesEmitter } = createPanelWithEditor(
+      '<div class="flex items-center p-4 rounded">',
+      { cursorLine: 0 },
+    )
     const messagesBefore = panel._getMessages().length
 
     // Simulate webview having focus — activeTextEditor is undefined
@@ -737,29 +752,28 @@ describe("regression: visibleTextEditors for text document changes", () => {
     // But the editor is still visible
     window.visibleTextEditors = [editor!]
 
-    _fireEvent("onDidChangeTextDocument", { document: editor!.document })
-    vi.advanceTimersByTime(200)
+    // Change ranges so content key differs
+    getClassRanges.mockReturnValue([
+      makeClassRange(0, 12, 0, 30, ["flex", "p-4", "rounded", "mt-2"], "div"),
+    ])
+    rangesEmitter.fire("file:///test.tsx")
 
     // Should still have found the editor and sent an update
     const newMessages = panel._getMessages().slice(messagesBefore)
     const updateMsg = newMessages.find((m) => m.type === "update")
     expect(updateMsg).toBeDefined()
-    vi.useRealTimers()
   })
 
-  it("ignores text changes for documents not in visibleTextEditors", () => {
-    vi.useFakeTimers()
-    const { panel } = createPanelWithEditor('<div class="flex items-center p-4 rounded">', {
-      cursorLine: 0,
-    })
+  it("ignores onDidUpdateRanges for URIs not matching currentEditorUri", () => {
+    const { panel, rangesEmitter } = createPanelWithEditor(
+      '<div class="flex items-center p-4 rounded">',
+      { cursorLine: 0 },
+    )
     const messagesBefore = panel._getMessages().length
 
-    // Fire a text change for a document that is not in any visible editor
-    const otherDoc = { uri: { toString: () => "file:///other.tsx" } }
-    _fireEvent("onDidChangeTextDocument", { document: otherDoc })
-    vi.advanceTimersByTime(200)
+    // Fire for a different URI
+    rangesEmitter.fire("file:///other.tsx")
 
     expect(panel._getMessages().length).toBe(messagesBefore)
-    vi.useRealTimers()
   })
 })

--- a/test/core/foldingProvider.test.ts
+++ b/test/core/foldingProvider.test.ts
@@ -14,6 +14,9 @@ import { FoldingManager } from "../../src/core/foldingProvider"
 function createManager(editorText?: string, opts?: { cursorLine?: number }) {
   const editor = editorText ? createMockEditor(editorText, opts) : undefined
   window.activeTextEditor = editor
+  if (editor) {
+    window.visibleTextEditors = [editor]
+  }
   const manager = new FoldingManager()
   return { editor, manager }
 }
@@ -274,6 +277,7 @@ describe("event handlers", () => {
       cursorLine: 1,
     })
     window.activeTextEditor = newEditor
+    window.visibleTextEditors = [newEditor]
 
     _fireEvent("onDidChangeActiveTextEditor", newEditor)
 
@@ -354,6 +358,113 @@ describe("event handlers", () => {
     })
 
     expect(editor!._decorationCalls).toHaveLength(0)
+  })
+})
+
+// ─── updateAllVisibleEditors ─────────────────────────────────────────
+
+describe("updateAllVisibleEditors", () => {
+  it("decorates all visible editors, not just the active one", () => {
+    const editor1 = createMockEditor('<div class="flex items-center p-4 rounded">', {
+      cursorLine: 1,
+    })
+    const editor2 = createMockEditor('<span class="text-sm font-bold mt-2 mx-auto">', {
+      cursorLine: 1,
+      uri: "file:///second.tsx",
+    })
+    window.activeTextEditor = editor1
+    window.visibleTextEditors = [editor1, editor2]
+    const manager = new FoldingManager()
+
+    // Both editors should have received decorations on construction
+    const has1 = editor1._decorationCalls.some((c) => c.decorations.length > 0)
+    const has2 = editor2._decorationCalls.some((c) => c.decorations.length > 0)
+    expect(has1).toBe(true)
+    expect(has2).toBe(true)
+
+    manager.dispose()
+  })
+
+  it("decorates new editors when visible text editors change", () => {
+    const editor1 = createMockEditor('<div class="flex items-center p-4 rounded">', {
+      cursorLine: 1,
+    })
+    window.activeTextEditor = editor1
+    window.visibleTextEditors = [editor1]
+    const manager = new FoldingManager()
+
+    const editor2 = createMockEditor('<span class="text-sm font-bold mt-2 mx-auto">', {
+      cursorLine: 1,
+      uri: "file:///second.tsx",
+    })
+    window.visibleTextEditors = [editor1, editor2]
+    _fireEvent("onDidChangeVisibleTextEditors", [editor1, editor2])
+
+    const has2 = editor2._decorationCalls.some((c) => c.decorations.length > 0)
+    expect(has2).toBe(true)
+
+    manager.dispose()
+  })
+})
+
+// ─── onDidUpdateRanges event ─────────────────────────────────────────
+
+describe("onDidUpdateRanges", () => {
+  it("fires when ranges are first detected for a new URI", () => {
+    // Start with no editor so initial construction doesn't detect anything
+    const manager = new FoldingManager()
+    const fired: string[] = []
+    manager.onDidUpdateRanges((uri) => fired.push(uri))
+
+    // Add an editor — first time this URI is processed
+    const editor = createMockEditor('<div class="flex items-center p-4 rounded">', {
+      cursorLine: 1,
+    })
+    window.activeTextEditor = editor
+    window.visibleTextEditors = [editor]
+    _fireEvent("onDidChangeActiveTextEditor", editor)
+
+    expect(fired).toContain("file:///test.tsx")
+
+    manager.dispose()
+  })
+
+  it("does not fire when ranges haven't changed", () => {
+    const editor = createMockEditor('<div class="flex items-center p-4 rounded">', {
+      cursorLine: 1,
+    })
+    window.activeTextEditor = editor
+    window.visibleTextEditors = [editor]
+
+    const manager = new FoldingManager()
+    const fired: string[] = []
+    manager.onDidUpdateRanges((uri) => fired.push(uri))
+
+    // Re-trigger decoration update — same document, same ranges
+    _fireEvent("onDidChangeActiveTextEditor", editor)
+
+    expect(fired).toHaveLength(0)
+
+    manager.dispose()
+  })
+
+  it("does not fire when disabled (no range detection)", () => {
+    const fired: string[] = []
+    const editor = createMockEditor('<div class="flex items-center p-4 rounded">', {
+      cursorLine: 1,
+    })
+    window.activeTextEditor = editor
+    window.visibleTextEditors = [editor]
+
+    const manager = new FoldingManager()
+    manager.onDidUpdateRanges((uri) => fired.push(uri))
+    fired.length = 0
+
+    manager.setEnabled(false)
+
+    expect(fired).toHaveLength(0)
+
+    manager.dispose()
   })
 })
 

--- a/test/integration/activation.test.ts
+++ b/test/integration/activation.test.ts
@@ -52,6 +52,7 @@ describe("collapseAll produces decorations on an active editor", () => {
   it("applies fold decorations after collapseAll command", () => {
     const editor = createMockEditor(HTML_WITH_CLASSES, { cursorLine: 0 })
     window.activeTextEditor = editor
+    window.visibleTextEditors = [editor]
     activate(makeContext())
 
     // The FoldingManager runs on construction, but let's explicitly collapse
@@ -68,6 +69,7 @@ describe("collapseAll produces decorations on an active editor", () => {
   it("clears all decorations after expandAll command", () => {
     const editor = createMockEditor(HTML_WITH_CLASSES, { cursorLine: 0 })
     window.activeTextEditor = editor
+    window.visibleTextEditors = [editor]
     activate(makeContext())
 
     editor._decorationCalls.splice(0)
@@ -81,6 +83,7 @@ describe("collapseAll produces decorations on an active editor", () => {
   it("toggleCollapse flips between folded and expanded", () => {
     const editor = createMockEditor(HTML_WITH_CLASSES, { cursorLine: 0 })
     window.activeTextEditor = editor
+    window.visibleTextEditors = [editor]
     activate(makeContext())
 
     // Should start enabled (foldByDefault = true) — toggle to disabled
@@ -102,6 +105,7 @@ describe("decoration content matches classDetector output", () => {
   it("placeholder count matches number of classes in the attribute", () => {
     const editor = createMockEditor(HTML_WITH_CLASSES, { cursorLine: 0 })
     window.activeTextEditor = editor
+    window.visibleTextEditors = [editor]
     activate(makeContext())
 
     const placeholderCalls = editor._decorationCalls.filter(
@@ -123,6 +127,7 @@ describe("decoration content matches classDetector output", () => {
   it("hover message contains class names from the document", () => {
     const editor = createMockEditor(HTML_WITH_CLASSES, { cursorLine: 0 })
     window.activeTextEditor = editor
+    window.visibleTextEditors = [editor]
     activate(makeContext())
 
     const placeholderCalls = editor._decorationCalls.filter(
@@ -221,7 +226,7 @@ describe("editor switch updates both folding and panel", () => {
 // ─── Text changes trigger both systems ──────────────────────────────
 
 describe("text change triggers both folding and panel refresh", () => {
-  it("document change debounces and updates both decorations and panel", () => {
+  it("document change debounces and updates decorations", () => {
     vi.useFakeTimers()
     const editor = createMockEditor(HTML_WITH_CLASSES, { cursorLine: 0 })
     window.activeTextEditor = editor
@@ -229,10 +234,8 @@ describe("text change triggers both folding and panel refresh", () => {
     activate(makeContext())
 
     _getCommandHandler("tailwindStash.showCssPreview")!()
-    const panel = _getLastPanel()
 
     editor._decorationCalls.splice(0)
-    const messagesAfterPanel = panel._getMessages().length
 
     // Simulate a text document change
     _fireEvent("onDidChangeTextDocument", { document: editor.document })
@@ -240,16 +243,37 @@ describe("text change triggers both folding and panel refresh", () => {
     // Before debounce, nothing should have updated
     expect(editor._decorationCalls).toHaveLength(0)
 
-    // Advance past both debounce timers (FoldingManager: 150ms, CSSPreviewPanel: 150ms)
+    // Advance past debounce timer (FoldingManager: 150ms)
     vi.advanceTimersByTime(200)
 
     // FoldingManager should have re-applied decorations
     expect(editor._decorationCalls.length).toBeGreaterThan(0)
+  })
 
-    // CSSPreviewPanel should have sent a new update
+  it("panel receives update when switching to an editor with different content", () => {
+    const editor1 = createMockEditor(HTML_WITH_CLASSES, { cursorLine: 0 })
+    window.activeTextEditor = editor1
+    window.visibleTextEditors = [editor1]
+    activate(makeContext())
+
+    _getCommandHandler("tailwindStash.showCssPreview")!()
+    const panel = _getLastPanel()
+    const messagesAfterPanel = panel._getMessages().length
+
+    // Switch to a different editor — FoldingManager fires onDidUpdateRanges,
+    // panel's onDidChangeActiveTextEditor calls updateForEditor
+    const editor2 = createMockEditor('<p class="mt-4 px-2 text-lg font-medium">Text</p>', {
+      cursorLine: 1,
+      uri: "file:///second.tsx",
+    })
+    window.activeTextEditor = editor2
+    window.visibleTextEditors = [editor1, editor2]
+    _fireEvent("onDidChangeActiveTextEditor", editor2)
+
     const newMessages = panel._getMessages().slice(messagesAfterPanel)
     const updateMsg = newMessages.find((m: { type: string }) => m.type === "update")
     expect(updateMsg).toBeDefined()
+    expect(updateMsg.entries[0].element).toBe("p")
   })
 })
 
@@ -260,6 +284,7 @@ describe("cursor movement integration", () => {
     vi.useFakeTimers()
     const editor = createMockEditor(HTML_WITH_CLASSES, { cursorLine: 0 })
     window.activeTextEditor = editor
+    window.visibleTextEditors = [editor]
     activate(makeContext())
 
     // Move cursor to line 1 (the button with classes)
@@ -318,6 +343,7 @@ describe("panel lifecycle through commands", () => {
   it("hideCssPreview disposes the panel created by showCssPreview", () => {
     const editor = createMockEditor(HTML_WITH_CLASSES, { cursorLine: 0 })
     window.activeTextEditor = editor
+    window.visibleTextEditors = [editor]
     activate(makeContext())
 
     _getCommandHandler("tailwindStash.showCssPreview")!()
@@ -330,6 +356,7 @@ describe("panel lifecycle through commands", () => {
   it("toggleCssPreview creates then destroys the panel", () => {
     const editor = createMockEditor(HTML_WITH_CLASSES, { cursorLine: 0 })
     window.activeTextEditor = editor
+    window.visibleTextEditors = [editor]
     activate(makeContext())
 
     _getCommandHandler("tailwindStash.toggleCssPreview")!()
@@ -342,6 +369,7 @@ describe("panel lifecycle through commands", () => {
   it("showCssPreview reveals existing panel instead of creating a new one", () => {
     const editor = createMockEditor(HTML_WITH_CLASSES, { cursorLine: 0 })
     window.activeTextEditor = editor
+    window.visibleTextEditors = [editor]
     activate(makeContext())
 
     _getCommandHandler("tailwindStash.showCssPreview")!()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "exclude": ["node_modules", ".vscode-test", "test", "scripts", "vitest.config.ts", "esbuild.webview.mts", "src/webview", "oxlint.config.mjs", "out"]
+  "exclude": ["node_modules", ".vscode-test", "test", "scripts", "sandbox", "vitest.config.ts", "esbuild.webview.mts", "src/webview", "oxlint.config.mjs", "out"]
 }


### PR DESCRIPTION
## Summary

- **Panel disconnect fix**: CSSPreviewPanel subscribes to a new `onDidUpdateRanges` event from FoldingManager, eliminating the race condition where the panel read stale ranges before the new editor was processed
- **Split-view decorations**: FoldingManager now decorates all visible editors via `updateAllVisibleEditors()`, not just the active one
- **Event efficiency**: `onDidUpdateRanges` only fires when detected ranges actually change (range key comparison), avoiding redundant work on cursor movement or editor switches with unchanged content
- **Sandbox**: 7 fixture files for manual F5 testing covering basics, split-view, panel sync, edge cases, stress test, function syntaxes, and empty-state

Closes #20 

## Test plan

- [x] `npm run format && npm run lint && npm run typecheck && npm run test:unit` — 334 tests pass
- [x] `npm run test:vscode` — 8 E2E smoke tests pass (VS Code 1.66.0)
- [x] CI passes
- [x] Manual F5 test with sandbox files: split-view decorations, panel sync on tab switch, rapid editing