### PR TITLE
Add Closes #N rule to PR workflow

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -22,6 +22,7 @@ Create a pull request for the current branch.
 8. Create the PR using `gh pr create`:
    - Derive the title from the branch name (e.g. `feat/class-sorting` becomes "Add class sorting").
    - Generate the PR body following the template in `.github/pull_request_template.md`. Fill in the summary, changes list, and check the appropriate type and checklist boxes.
+   - If the branch or commits reference a GitHub issue number, include `Closes #N` in the "Related issues" section of the PR body. This must be present at merge time for GitHub to auto-close the issue.
    - Target `master`.
 9. Print the PR URL.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,4 +25,6 @@
 
 ## Related issues
 
-<!-- Link any related issues: Fixes #123 -->
+<!-- If this PR fixes an issue, add "Closes #N" here (not in a comment).
+     GitHub auto-closes the issue when the PR merges. -->
+Closes #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ Rules:
 
 - **Never push directly to master.** Branch protection requires a pull request with all status checks passing.
 - Always create a branch, push it, open a PR via `gh pr create`, wait for CI, then merge via `gh pr merge`.
+- When a PR fixes a GitHub issue, include `Closes #N` in the PR body **before merging** (not in a comment). GitHub only auto-closes issues when the keyword is present at merge time.
 
 ### Message protocol
 


### PR DESCRIPTION
## Summary

- PR template now has `Closes #` pre-filled (not hidden in a comment)
- CLAUDE.md documents that `Closes #N` must be in the PR body before merging
- PR skill instructs auto-detecting issue refs and including `Closes #N`

## Test plan

- [x] Docs-only change, no code affected