### PR TITLE
Warn when supportedFunctions contains an invalid regex

### DIFF
--- a/src/core/classDetector.ts
+++ b/src/core/classDetector.ts
@@ -12,6 +12,21 @@ export interface ClassRange {
   range: vscode.Range
 }
 
+const warnedInvalidSupportedFunctionPatterns = new Set<string>()
+
+function warnInvalidSupportedFunctionPattern(pattern: string, error: unknown) {
+  if (warnedInvalidSupportedFunctionPatterns.has(pattern)) {
+    return
+  }
+
+  warnedInvalidSupportedFunctionPatterns.add(pattern)
+
+  const suffix = error instanceof Error && error.message ? `: ${error.message}` : ""
+  vscode.window.showWarningMessage(
+    `Tailwind Stash: invalid supportedFunctions regex "${pattern}" was ignored${suffix}`,
+  )
+}
+
 /**
  * Detects Tailwind class strings in a document, including those wrapped
  * in utility functions like cn(), clsx(), cva(), twMerge(), etc.
@@ -53,6 +68,12 @@ export function detectClassRanges(
       // Strip ^/$ anchors — they don't work inside a group in a larger regex.
       // Use \b boundaries instead for correct matching.
       const cleaned = regexMatch[1].replace(/^\^/, "").replace(/\$$/, "")
+      try {
+        new RegExp(cleaned)
+      } catch (error) {
+        warnInvalidSupportedFunctionPattern(fn, error)
+        continue
+      }
       regexPatterns.push(`\\b${cleaned}`)
     } else {
       literalNames.push(escapeRegex(fn))

--- a/test/__mocks__/vscode.ts
+++ b/test/__mocks__/vscode.ts
@@ -371,6 +371,7 @@ export const window = {
   onDidChangeActiveTextEditor: makeEventEmitter("onDidChangeActiveTextEditor"),
   onDidChangeTextEditorSelection: makeEventEmitter("onDidChangeTextEditorSelection"),
   showInformationMessage(_msg: string) {},
+  showWarningMessage(_msg: string) {},
   showTextDocument() {},
   visibleTextEditors: [] as unknown[],
 }

--- a/test/core/classDetector.test.ts
+++ b/test/core/classDetector.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { createMockDocument } from "../__mocks__/vscode"
+import { createMockDocument, window } from "../__mocks__/vscode"
 import { detectClassRanges } from "../../src/core/classDetector"
 
 const defaultFunctions = [
@@ -13,6 +13,10 @@ const defaultFunctions = [
   "classNames",
   "classnames",
 ]
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 function detect(text: string, opts?: { functions?: string[]; minClasses?: number }) {
   const doc = createMockDocument(text)
@@ -430,6 +434,36 @@ describe("empty and invalid function patterns", () => {
     const results = detect('<div class="flex items-center p-4 rounded">', { functions: [] })
     expect(results).toHaveLength(1)
     expect(results[0].element).toBe("div")
+  })
+
+  it("warns once and keeps valid detections when a regex pattern is invalid", () => {
+    const warningSpy = vi.spyOn(window, "showWarningMessage")
+    const text = `
+const a = cn("flex items-center p-4 rounded");
+const b = getButtonClasses("grid gap-4 p-6 bg-white");
+<div class="text-sm font-bold mt-2 mx-auto"></div>
+`
+
+    const results = detect(text, {
+      functions: ["cn", "/[invalid(/", "/^get.*Classes$/"],
+    })
+
+    expect(results).toHaveLength(3)
+    expect(warningSpy).toHaveBeenCalledTimes(1)
+    expect(warningSpy.mock.calls[0]?.[0]).toContain("/[invalid(/")
+  })
+
+  it("does not repeat the warning for the same invalid regex pattern", () => {
+    const warningSpy = vi.spyOn(window, "showWarningMessage")
+
+    detect('<div class="flex items-center p-4 rounded">', {
+      functions: ["/[still-invalid(/"],
+    })
+    detect('<div class="flex items-center p-4 rounded">', {
+      functions: ["/[still-invalid(/"],
+    })
+
+    expect(warningSpy).toHaveBeenCalledTimes(1)
   })
 
   it("returns results gracefully when regex pattern is invalid", () => {


### PR DESCRIPTION
## Summary
- validate regex-style `supportedFunctions` entries before building the combined detector pattern
- warn once per invalid pattern instead of silently returning empty utility-function matches
- keep valid literal and regex function matches working even when one entry is malformed
- extend the class detector tests to cover the warning path and non-spam behavior

## Verification
- `npx vitest run test/core/classDetector.test.ts`
- `npm run typecheck`
- `./node_modules/.bin/oxfmt --check src/core/classDetector.ts test/core/classDetector.test.ts test/__mocks__/vscode.ts`
- `git diff --check`

Closes #22