### PR TITLE
Fix panel not recovering classes after focus loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the Tailwind Stash extension will be documented in this f
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.2.5] - 2026-03-14
+
+### Fixed
+
+- Fix panel not recovering classes after switching to non-editor views (Extensions, Terminal) and back
+- Fix stale content key preventing full panel update when webview is recreated without an active editor
+- Add `onDidChangeViewState` handler to force panel resend when it becomes visible after being hidden
+
+### Added
+
+- 4 new regression tests for panel recovery scenarios (338 total)
+
 ## [0.2.4] - 2026-03-14
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tailwind-stash",
   "displayName": "Tailwind Stash",
   "description": "Collapse Tailwind CSS class strings with bi-directional editor panel",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "license": "MIT",
   "publisher": "beumerr",
   "repository": {

--- a/src/core/cssPreviewPanel.ts
+++ b/src/core/cssPreviewPanel.ts
@@ -34,6 +34,20 @@ export class CSSPreviewPanel {
 
     this.panel.onDidDispose(() => this.dispose(), null, this.disposables)
 
+    this.panel.onDidChangeViewState(
+      (e) => {
+        if (e.webviewPanel.visible) {
+          this.lastContentKey = ""
+          const ed = vscode.window.activeTextEditor
+          if (ed && ed.document.uri.scheme !== "output") {
+            this.updateForEditor(ed)
+          }
+        }
+      },
+      null,
+      this.disposables,
+    )
+
     this.panel.webview.onDidReceiveMessage((msg) => this.handleMessage(msg), null, this.disposables)
 
     this.disposables.push(
@@ -50,6 +64,8 @@ export class CSSPreviewPanel {
       vscode.window.onDidChangeActiveTextEditor((editor) => {
         if (editor && editor.document.uri.scheme !== "output") {
           this.updateForEditor(editor)
+        } else if (!editor) {
+          this.lastContentKey = ""
         }
       }),
       onDidUpdateRanges((uri) => {
@@ -121,9 +137,9 @@ export class CSSPreviewPanel {
   private async handleMessage(msg: { classes?: string; index?: number; type: string }) {
     if (msg.type === "ready") {
       this.sendConfig()
+      this.lastContentKey = ""
       const editor = vscode.window.activeTextEditor
       if (editor && editor.document.uri.scheme !== "output") {
-        this.lastContentKey = ""
         this.updateForEditor(editor)
       }
       return

--- a/test/__mocks__/vscode.ts
+++ b/test/__mocks__/vscode.ts
@@ -352,23 +352,31 @@ export interface MockMessage {
 export function createMockWebviewPanel() {
   let disposeCallback: (() => void) | undefined
   let messageCallback: ((msg: unknown) => void) | undefined
+  let viewStateCallback: ((e: { webviewPanel: { visible: boolean } }) => void) | undefined
   let disposed = false
   const messages: MockMessage[] = []
   const panel = {
     _getMessages: () => messages,
     _simulateDispose: () => disposeCallback?.(),
     _simulateMessage: (msg: unknown) => messageCallback?.(msg),
+    _simulateViewStateChange: (visible: boolean) =>
+      viewStateCallback?.({ webviewPanel: { visible } }),
     dispose() {
       if (!disposed) {
         disposed = true
         disposeCallback?.()
       }
     },
+    onDidChangeViewState(cb: (e: { webviewPanel: { visible: boolean } }) => void) {
+      viewStateCallback = cb
+      return { dispose() {} }
+    },
     onDidDispose(cb: () => void) {
       disposeCallback = cb
       return { dispose() {} }
     },
     reveal() {},
+    visible: true,
     webview: {
       html: "",
       onDidReceiveMessage(cb: (msg: unknown) => void) {

--- a/test/core/cssPreviewPanel.test.ts
+++ b/test/core/cssPreviewPanel.test.ts
@@ -739,6 +739,74 @@ describe("regression: panel shows classes on open (ready message)", () => {
   })
 })
 
+describe("regression: panel recovery after editor focus loss", () => {
+  it("resets content key when active editor becomes undefined", () => {
+    const { editor, panel } = createPanelWithEditor('<div class="flex items-center p-4 rounded">', {
+      cursorLine: 0,
+    })
+
+    // Simulate switching to a non-editor view (e.g. Extensions sidebar)
+    _fireEvent("onDidChangeActiveTextEditor", undefined)
+
+    // Now switch back to the same editor
+    const messagesBefore = panel._getMessages().length
+    window.activeTextEditor = editor
+    _fireEvent("onDidChangeActiveTextEditor", editor)
+
+    // Should send a full update (not just setActive) because content key was reset
+    const newMessages = panel._getMessages().slice(messagesBefore)
+    const updateMsg = newMessages.find((m) => m.type === "update")
+    expect(updateMsg).toBeDefined()
+  })
+
+  it("resends full update when panel becomes visible after being hidden", () => {
+    const { panel } = createPanelWithEditor('<div class="flex items-center p-4 rounded">', {
+      cursorLine: 0,
+    })
+    const messagesBefore = panel._getMessages().length
+
+    // Simulate panel becoming visible again (webview may have been recreated)
+    panel._simulateViewStateChange(true)
+
+    const newMessages = panel._getMessages().slice(messagesBefore)
+    const updateMsg = newMessages.find((m) => m.type === "update")
+    expect(updateMsg).toBeDefined()
+  })
+
+  it("does not send update when panel becomes hidden", () => {
+    const { panel } = createPanelWithEditor('<div class="flex items-center p-4 rounded">', {
+      cursorLine: 0,
+    })
+    const messagesBefore = panel._getMessages().length
+
+    panel._simulateViewStateChange(false)
+
+    const newMessages = panel._getMessages().slice(messagesBefore)
+    const updateMsg = newMessages.find((m) => m.type === "update")
+    expect(updateMsg).toBeUndefined()
+  })
+
+  it("ready message resets content key even without active editor", () => {
+    const { editor, panel } = createPanelWithEditor('<div class="flex items-center p-4 rounded">', {
+      cursorLine: 0,
+    })
+
+    // Simulate no active editor when ready fires
+    window.activeTextEditor = undefined
+    panel._simulateMessage({ type: "ready" })
+
+    // Now restore the editor and trigger an editor change
+    const messagesBefore = panel._getMessages().length
+    window.activeTextEditor = editor
+    _fireEvent("onDidChangeActiveTextEditor", editor)
+
+    // Should send a full update because ready reset the content key
+    const newMessages = panel._getMessages().slice(messagesBefore)
+    const updateMsg = newMessages.find((m) => m.type === "update")
+    expect(updateMsg).toBeDefined()
+  })
+})
+
 describe("regression: onDidUpdateRanges finds editor via visibleTextEditors", () => {
   it("uses visibleTextEditors to find editor when activeTextEditor is undefined", () => {
     const { editor, getClassRanges, panel, rangesEmitter } = createPanelWithEditor(


### PR DESCRIPTION
## Summary

- Reset `lastContentKey` when `onDidChangeActiveTextEditor` fires with `undefined` (user switched to Extensions, Terminal, etc.) so the next editor switch sends a full update
- Move `lastContentKey` reset in the "ready" handler outside the `if (editor)` block, fixing the race where webview reloads without an active editor
- Add `onDidChangeViewState` handler to force a full resend when the panel becomes visible after being hidden

Closes #20

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test:unit` — 338 tests pass
- [x] Manual test: open file with classes → open Extensions sidebar → click back on file → panel shows classes